### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -137,7 +137,7 @@ $(document).ready(function () {
     var arr = new Array();
     $(".filter").each(function () {
         arr = $(this).attr("data-filter").slice();
-        $(this).children(".cat-count").text($(arr).length);
+        $(this).children(".cat-count").text($.find(arr).length);
     });
 
     $(".all").children(".cat-count").text($('.mix').length);


### PR DESCRIPTION
Potential fix for [https://github.com/aneeraj/main-site/security/code-scanning/1](https://github.com/aneeraj/main-site/security/code-scanning/1)

Use an API that treats the value strictly as a CSS selector instead of potentially as HTML.  
In this snippet, the safest minimal change is to replace `$(arr).length` with `$.find(arr).length` at line 140.

Why this is best here:
- Preserves current functionality (counting matching elements).
- Eliminates the risky `$()` interpretation path.
- Requires no broader refactor or behavior change.

**File/region to change:** `assets/js/scripts.js`, in the “Filters” block around lines 137–141.  
**Needed additions:** none (no new imports, methods, or dependencies).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
